### PR TITLE
blocking access to users that aren't admins

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -10,10 +10,10 @@ module Admin
     before_action :authenticate_admin
 
     def authenticate_admin
-      # TODO Add authentication logic here.
-      current_user.admin
-    end
 
+    redirect_to root_path unless current_user.admin?
+
+    end
     # Override this value to specify the number of elements to display at a time
     # on index pages. Defaults to 20.
     # def records_per_page


### PR DESCRIPTION
I've blocked the access to users that aren't admins by using "redirect_to root_path unless current_user.admin?" in the admin application_controller.